### PR TITLE
Extend Docker image to run ASR & SD tasks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN apt-get update --fix-missing && apt-get install -y wget \
 
 RUN python -m pip install --upgrade pip
 RUN python -m pip --no-cache-dir install fairseq@git+https://github.com//pytorch/fairseq.git@f2146bdc7abf293186de9449bfa2272775e39e1d#egg=fairseq
-RUN python -m pip --no-cache-dir install git+https://github.com/osanseviero/s3prl.git@huggingface2#egg=s3prl
+RUN python -m pip --no-cache-dir install git+https://github.com/huggingface/s3prl.git@huggingface2#egg=s3prl
 
 COPY s3prl/ /app/s3prl
 COPY src/ /app/src

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,8 +23,8 @@ RUN mkdir /app/data
 # Fine-tune!
 ENV upstream_model hubert
 ENV downstream_task asr
-ENV expt_name asr
 
 WORKDIR /app/s3prl
 # Each task's config.yaml is used to set all the training parameters
-CMD python run_downstream.py -n ${expt_name} -m train -u ${upstream_model} -d ${downstream_task}
+# The results of each training run are stored in /app/s3prl/result/downstream/{downstream_task}
+CMD python run_downstream.py -n ${downstream_task} -m train -u ${upstream_model} -d ${downstream_task}

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,12 +20,11 @@ COPY src/ /app/src
 # Setup filesystem
 RUN mkdir /app/data
 
-WORKDIR /app/s3prl
-
 # Fine-tune!
-ENV batch_size 32
 ENV upstream_model hubert
 ENV downstream_task asr
 ENV expt_name asr
-# TODO: Consider using each task's config.yaml to set all the -o parameters
-CMD python run_downstream.py -n ${expt_name} -m train -u ${upstream_model} -d ${downstream_task} -o "config.downstream_expert.datarc.dict_path='./downstream/asr/char.dict',,config.downstream_expert.datarc.libri_root='/app/data/LibriSpeech',,config.downstream_expert.datarc.batch_size=${batch_size},,config.downstream_expert.datarc.bucket_file='/app/data/LibriSpeech/len_for_bucket'"
+
+WORKDIR /app/s3prl
+# Each task's config.yaml is used to set all the training parameters
+CMD python run_downstream.py -n ${expt_name} -m train -u ${upstream_model} -d ${downstream_task}

--- a/s3prl/downstream/README.md
+++ b/s3prl/downstream/README.md
@@ -173,8 +173,10 @@ docker build -t s3prl:latest .
 Then run the container the [NVIDIA Container Toolkit](https://github.com/NVIDIA/nvidia-docker) and with the data mounted as follows:
 
 ```
-docker run --gpus all -it -P -v /path/to/superb/data:/app/data s3prl
+docker run --gpus all -it -P -v /data/lewis/superb:/app/data -e "upstream_model=model_name" -e "downstream_task=task_name" s3prl
 ```
+
+where `model_name` and `task_name` correspond to one of the supported models / tasks in `s3prl`.
 
 # SUPERB Benchmark
 

--- a/s3prl/downstream/README.md
+++ b/s3prl/downstream/README.md
@@ -173,7 +173,7 @@ docker build -t s3prl:latest .
 Then run the container the [NVIDIA Container Toolkit](https://github.com/NVIDIA/nvidia-docker) and with the data mounted as follows:
 
 ```
-docker run --gpus all -it -P -v /data/lewis/superb:/app/data -e "upstream_model=model_name" -e "downstream_task=task_name" s3prl
+docker run --gpus all -it -P -v /path/to/superb/data:/app/data -e "upstream_model=model_name" -e "downstream_task=task_name" s3prl
 ```
 
 where `model_name` and `task_name` correspond to one of the supported models / tasks in `s3prl`.

--- a/s3prl/downstream/asr/config.yaml
+++ b/s3prl/downstream/asr/config.yaml
@@ -41,9 +41,11 @@ downstream_expert:
     test-other: ['test-other']
     num_workers: 12
     train_batch_size: 32
+    batch_size: 32
     eval_batch_size: 1
-    libri_root: '/path/to/LibriSpeech'
-    bucket_file: 'data/librispeech/len_for_bucket'
+    libri_root: '/app/data/LibriSpeech'
+    bucket_file: '/app/data/LibriSpeech/len_for_bucket'
+    dict_path: "./downstream/asr/char.dict"
 
     zero_infinity: True
 

--- a/s3prl/downstream/diarization/config.yaml
+++ b/s3prl/downstream/diarization/config.yaml
@@ -28,9 +28,9 @@ downstream_expert:
     num_workers: 8
     train_batchsize: 8
     eval_batchsize: 1
-    train_dir: ./data/Libri2Mix/train
-    dev_dir: ./data/Libri2Mix/dev
-    test_dir: ./data/Libri2Mix/test
+    train_dir: /app/data/Libri2Mix/train
+    dev_dir: /app/data/Libri2Mix/dev
+    test_dir: /app/data/Libri2Mix/test
 
   scorerc:
     save_predictions: True


### PR DESCRIPTION
This PR generalises the Dockerfile for fine-tuning to support both ASR and SD tasks. The current usage is as follows:

```
# build image
docker build -t s3prl:latest .
# run container
docker run --gpus all -it -P -v /path/to/superb/data:/app/data -e "upstream_model=model_name" -e "downstream_task=task_name" s3prl
```

cc @Narsil @osanseviero @albertvillanova 