### PR TITLE
Use upstream models from the Hugging Face Hub

### DIFF
--- a/s3prl/downstream/runner.py
+++ b/s3prl/downstream/runner.py
@@ -81,7 +81,7 @@ class Runner():
 
             from expert import UpstreamExpert
             Upstream = UpstreamExpert
-            ckpt_path = os.path.join(filepath, "model.pt")
+            ckpt_path = os.path.join(filepath, self.args.upstream_model_name)
         else:
             Upstream = getattr(hub, self.args.upstream)
             ckpt_path = self.args.upstream_ckpt

--- a/s3prl/downstream/runner.py
+++ b/s3prl/downstream/runner.py
@@ -75,7 +75,7 @@ class Runner():
         if "from_hf_hub" in self.args and self.args.from_hf_hub == True:
             from huggingface_hub import snapshot_download
 
-            print(f'Downloading upstream model from the Hugging Face Hub {self.args.upstream}')
+            print(f'Downloading upstream model {self.args.upstream} from the Hugging Face Hub')
             filepath = snapshot_download(self.args.upstream)
             sys.path.append(filepath)
 

--- a/s3prl/downstream/runner.py
+++ b/s3prl/downstream/runner.py
@@ -72,7 +72,19 @@ class Runner():
 
 
     def _get_upstream(self):
-        Upstream = getattr(hub, self.args.upstream)
+        if "from_hf_hub" in self.args and self.args.from_hf_hub == True:
+            from huggingface_hub import snapshot_download
+
+            print(f'Downloading upstream model from the Hugging Face Hub {self.args.upstream}')
+            filepath = snapshot_download(self.args.upstream)
+            sys.path.append(filepath)
+
+            from expert import UpstreamExpert
+            Upstream = UpstreamExpert
+            ckpt_path = os.path.join(filepath, "model.pt")
+        else:
+            Upstream = getattr(hub, self.args.upstream)
+            ckpt_path = self.args.upstream_ckpt
         upstream_refresh = self.args.upstream_refresh
 
         if is_initialized() and get_rank() > 0:
@@ -80,7 +92,7 @@ class Runner():
             upstream_refresh = False
 
         model = Upstream(
-            ckpt = self.args.upstream_ckpt,
+            ckpt = ckpt_path,
             model_config = self.args.upstream_model_config,
             refresh = upstream_refresh,
         ).to(self.args.device)


### PR DESCRIPTION
This PR enables using upstream models from the Hugging Face Hub.

Downstream models just need to be configured as follows:
```
ckp["Args"].upstream = "osanseviero/hubert_base"
ckp["Args"].upstream_model_name = "model.pt"
ckp["Args"].from_hf_hub = True
``` 

Example downstream: https://huggingface.co/osanseviero/hubert_asr_using_hub
Example upstream: https://huggingface.co/osanseviero/hubert_base

Upstream repo needs to implement the `UpstreamExpert` class in the `expert` file.